### PR TITLE
Fix build errors and add local build scripts

### DIFF
--- a/combined/.gitignore
+++ b/combined/.gitignore
@@ -154,3 +154,5 @@ test/.test-sites/
 screenshots/
 lighthouse-reports/
 src/assets/icons/iconify/test/
+
+.claude

--- a/package.json
+++ b/package.json
@@ -3,5 +3,15 @@
 	"version": "1.0.0",
 	"type": "module",
 	"packageManager": "bun@1.2.13",
-	"description": "VeganPrestwich.co.uk - The best vegan finds in Prestwich"
+	"description": "VeganPrestwich.co.uk - The best vegan finds in Prestwich",
+	"scripts": {
+		"preinstall": "node -e \"if(!process.env.npm_config_user_agent.startsWith('bun')){console.error('Use bun, not npm/yarn/pnpm');process.exit(1)}\"",
+		"serve": "bun scripts/serve.js",
+		"build": "bun scripts/build.js",
+		"prepare-dev": "bun scripts/prepare-dev.js",
+		"sync-files": "bun scripts/sync-files.js",
+		"watch": "bun scripts/watch.js",
+		"clean": "rm -rf .build _site",
+		"update-scripts": "bun scripts/update-scripts.js"
+	}
 }

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,4 +1,5 @@
 {
 	"tags": ["pages"],
-	"layout": "page.html"
+	"layout": "page.html",
+	"permalink": "/{{ page.fileSlug }}/index.html"
 }

--- a/products/products.json
+++ b/products/products.json
@@ -3,5 +3,6 @@
 	"tags": ["products"],
 	"reviewsField": "products",
 	"permalink": "/place/{{ page.fileSlug }}/index.html",
-	"votes": 0
+	"votes": 0,
+	"filter_attributes": []
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+import { prep } from "./prepare-dev.js";
+import { bun, fs, path } from "./utils.js";
+
+const dev = path(".build", "dev");
+const output = path("_site");
+
+prep();
+
+console.log("Building site...");
+
+fs.rm(output);
+const result = bun.run("build", dev);
+
+if (result.exitCode !== 0) {
+  console.error(`\n${"=".repeat(60)}`);
+  console.error("BUILD FAILED");
+  console.error("=".repeat(60));
+  console.error("\nFix the error above and rebuild.\n");
+  process.exit(result.exitCode);
+}
+
+fs.mv(join(dev, "_site"), output);
+
+console.log("Built to _site/");

--- a/scripts/ci-merge.js
+++ b/scripts/ci-merge.js
@@ -1,0 +1,26 @@
+import { resolve } from "node:path";
+import { sourceExcludes, templateExcludes } from "./consts.js";
+import { fs, mergeTemplateAndSource } from "./utils.js";
+
+const [templateDir, sourceDir, combinedDir] = process.argv.slice(2);
+
+if (!templateDir || !sourceDir || !combinedDir) {
+  console.error(
+    "Usage: bun scripts/ci-merge.js <template> <source> <combined>",
+  );
+  process.exit(1);
+}
+
+const template = resolve(templateDir);
+const source = resolve(sourceDir);
+const combined = resolve(combinedDir);
+
+console.log(`Merging template and source into ${combined}...`);
+fs.mkdir(combined);
+mergeTemplateAndSource(template, source, combined, {
+  delete: true,
+  templateExcludes,
+  sourceExcludes,
+});
+
+console.log("Merge complete.");

--- a/scripts/consts.js
+++ b/scripts/consts.js
@@ -1,0 +1,27 @@
+export const templateRepo = "https://github.com/chobbledotcom/chobble-template";
+export const buildDir = ".build";
+
+export const templateExcludes = [
+  ".git",
+  ".direnv",
+  "node_modules",
+  "*.md",
+  "test",
+  "test-*",
+  ".image-cache",
+  "landing-pages",
+  "instagram-posts",
+];
+
+export const sourceExcludes = [
+  ".*",
+  "*.nix",
+  "README.md",
+  "scripts",
+  "node_modules",
+  "package*.json",
+  "bun.lock",
+  "old_site",
+  "combined",
+  ...(process.env.PLACEHOLDER_IMAGES === "1" ? ["images"] : []),
+];

--- a/scripts/prepare-dev.js
+++ b/scripts/prepare-dev.js
@@ -1,0 +1,69 @@
+import { join } from "node:path";
+import {
+  buildDir,
+  sourceExcludes,
+  templateExcludes,
+  templateRepo,
+} from "./consts.js";
+import {
+  bun,
+  copyDir,
+  find,
+  fs,
+  git,
+  mergeTemplateAndSource,
+  path,
+  root,
+} from "./utils.js";
+
+const build = path(buildDir);
+const template = path(buildDir, "template");
+const dev = path(buildDir, "dev");
+const localTemplate = join(root, "..", "chobble-template");
+
+export const prep = () => {
+  console.log("Preparing build...");
+  fs.mkdir(build);
+
+  if (fs.exists(localTemplate)) {
+    console.log("Using local template from ../chobble-template...");
+    copyDir(localTemplate, template, {
+      delete: true,
+      exclude: templateExcludes,
+    });
+  } else if (!fs.exists(join(template, ".git"))) {
+    console.log("Cloning template...");
+    fs.rm(template);
+    git.clone(templateRepo, template);
+  } else {
+    console.log("Updating template...");
+    git.reset(template, { hard: true });
+    git.pull(template);
+  }
+
+  find.deleteByExt(dev, ".md");
+  mergeTemplateAndSource(template, root, dev, {
+    delete: true,
+    templateExcludes,
+    sourceExcludes,
+  });
+
+  sync();
+
+  if (!fs.exists(join(dev, "node_modules"))) {
+    console.log("Installing dependencies...");
+    bun.install(dev);
+  }
+
+  fs.rm(join(dev, "_site"));
+  console.log("Build ready.");
+};
+
+export const sync = () => {
+  copyDir(root, join(dev, "src"), {
+    update: true,
+    exclude: sourceExcludes,
+  });
+};
+
+if (import.meta.main) prep();

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,18 @@
+import { prep } from "./prepare-dev.js";
+import { bun, path, spawn } from "./utils.js";
+
+const dev = path(".build", "dev");
+
+prep();
+
+console.log("Starting server...");
+
+const watchProc = spawn(["bun", path("scripts", "watch.js")]);
+const eleventyProc = bun.spawn("serve", dev);
+
+process.on("SIGINT", () => {
+  console.log("\nStopping...");
+  watchProc.kill();
+  eleventyProc.kill();
+  process.exit();
+});

--- a/scripts/sync-files.js
+++ b/scripts/sync-files.js
@@ -1,0 +1,5 @@
+import { sync } from "./prepare-dev.js";
+
+if (import.meta.main) sync();
+
+export { sync };

--- a/scripts/update-scripts.js
+++ b/scripts/update-scripts.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+
+/**
+ * Update scripts from chobble-client repo
+ * Copies scripts from chobbledotcom/chobble-client over our own
+ * without deleting any extra scripts we've added locally
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { $ } from "bun";
+import { copyDir } from "./utils.js";
+
+const REPO_URL = "https://github.com/chobbledotcom/chobble-client.git";
+const SCRIPT_DIR = dirname(import.meta.path);
+
+async function main() {
+  const tempDir = await mkdtemp(join(tmpdir(), "chobble-client-"));
+
+  try {
+    console.log("Fetching scripts from chobble-client...");
+
+    // Clone with sparse checkout for just the scripts directory
+    await $`git clone --depth 1 --filter=blob:none --sparse ${REPO_URL} ${tempDir}/chobble-client`.quiet();
+    await $`git -C ${tempDir}/chobble-client sparse-checkout set scripts`.quiet();
+
+    const sourceDir = join(tempDir, "chobble-client", "scripts");
+
+    console.log("Copying scripts...");
+
+    copyDir(sourceDir, SCRIPT_DIR, {
+      exclude: ["update-scripts.js", "update-scripts.sh"],
+    });
+
+    console.log("Done! Your local-only scripts have been preserved.");
+  } catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+  } finally {
+    // Cleanup
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,177 @@
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { extname, join, resolve } from "node:path";
+
+// Paths
+export const root = resolve(import.meta.dir, "..");
+export const path = (...segments) => join(root, ...segments);
+
+// File operations using Bun APIs
+export const file = (p) => Bun.file(p);
+export const exists = (p) => file(p).exists();
+export const read = (p) => file(p).text();
+export const readJson = async (p) => JSON.parse(await read(p));
+export const write = Bun.write;
+
+// Filesystem commands
+export const fs = {
+  exists: existsSync,
+  rm: (p) => rmSync(p, { recursive: true, force: true }),
+  mkdir: (p) => mkdirSync(p, { recursive: true }),
+  cp: (src, dest) => cpSync(src, dest, { recursive: true }),
+  mv: renameSync,
+};
+
+// Shell primitives
+export const run = (cmd, opts = {}) =>
+  Bun.spawnSync(cmd, { stdio: ["inherit", "inherit", "inherit"], ...opts });
+
+export const shell = (cmd, opts = {}) => run(["sh", "--", "-c", cmd], opts);
+
+export const spawn = (cmd, opts = {}) =>
+  Bun.spawn(cmd, { stdio: ["inherit", "inherit", "inherit"], ...opts });
+
+// Git commands
+export const git = {
+  clone: (repo, dest, opts = {}) =>
+    run(["git", "clone", "--depth", String(opts.depth || 1), repo, dest]),
+
+  pull: (dir) =>
+    run(["git", "--git-dir", join(dir, ".git"), "--work-tree", dir, "pull"]),
+
+  reset: (dir, opts = {}) =>
+    run([
+      "git",
+      "--git-dir",
+      join(dir, ".git"),
+      "--work-tree",
+      dir,
+      "reset",
+      opts.hard ? "--hard" : "--soft",
+    ]),
+};
+
+// Directory sync (replaces rsync)
+const globToRegex = (pattern) => {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const globs = escaped
+    .replaceAll("**", "\0")
+    .replaceAll("*", "[^/]*")
+    .replaceAll("\0", ".*");
+  return new RegExp(`^${globs}$`);
+};
+
+const isExcluded = (name, relPath, excludes) =>
+  excludes.some((p) => {
+    const regex = globToRegex(p);
+    return regex.test(name) || regex.test(relPath);
+  });
+
+const isNewer = (srcPath, destPath) =>
+  !existsSync(destPath) ||
+  statSync(srcPath).mtimeMs > statSync(destPath).mtimeMs;
+
+const shouldCopy = (srcPath, destPath, update) =>
+  !update || isNewer(srcPath, destPath);
+
+const copyFile = (srcPath, destPath) => {
+  cpSync(srcPath, destPath);
+  chmodSync(destPath, statSync(srcPath).mode);
+};
+
+const entryRelPath = (relBase, name) => (relBase ? `${relBase}/${name}` : name);
+
+const copyRecursive = (src, dest, excludes, update, relBase = "") => {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const relPath = entryRelPath(relBase, entry.name);
+    if (isExcluded(entry.name, relPath, excludes)) continue;
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyRecursive(srcPath, destPath, excludes, update, relPath);
+    } else if (shouldCopy(srcPath, destPath, update)) {
+      copyFile(srcPath, destPath);
+    }
+  }
+};
+
+const removeIfMissing = (destPath, srcPath, relPath, excludes) => {
+  if (!existsSync(srcPath)) rmSync(destPath, { recursive: true, force: true });
+  else if (statSync(destPath).isDirectory())
+    deleteMissing(destPath, srcPath, relPath, excludes);
+};
+
+const deleteMissing = (dest, src, relBase, excludes) => {
+  if (!existsSync(dest)) return;
+  for (const entry of readdirSync(dest, { withFileTypes: true })) {
+    const relPath = entryRelPath(relBase, entry.name);
+    if (isExcluded(entry.name, relPath, excludes)) continue;
+    removeIfMissing(
+      join(dest, entry.name),
+      join(src, entry.name),
+      relPath,
+      excludes,
+    );
+  }
+};
+
+export const copyDir = (src, dest, opts = {}) => {
+  const excludes = opts.exclude || [];
+  if (opts.delete) deleteMissing(dest, src, "", excludes);
+  copyRecursive(src, dest, excludes, opts.update || false);
+};
+
+export const mergeTemplateAndSource = (template, source, dest, opts = {}) => {
+  copyDir(template, dest, {
+    delete: opts.delete,
+    exclude: opts.templateExcludes || [],
+  });
+  copyDir(source, join(dest, "src"), {
+    update: opts.update,
+    exclude: opts.sourceExcludes || [],
+  });
+};
+
+// Bun commands
+export const bun = {
+  install: (cwd) => run(["bun", "install"], { cwd }),
+  run: (script, cwd) => run(["bun", "run", script], { cwd }),
+  test: (cwd) => run(["bun", "test"], { cwd }),
+  spawn: (script, cwd) => spawn(["bun", "run", script], { cwd, shell: true }),
+};
+
+// Find commands
+export const find = {
+  deleteByExt: (dir, ext) =>
+    shell(`find "${dir}" -type f -name "*${ext}" -delete 2>/dev/null || true`),
+};
+
+// Utilities
+export const ext = extname;
+
+export const debounce = (fn, ms) => {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+};
+
+export const loadEnv = async (p = path(".env")) => {
+  if (!(await exists(p))) return;
+  for (const line of (await read(p)).split("\n")) {
+    const [key, ...val] = line.split("=");
+    if (key && val.length && !process.env[key]) {
+      process.env[key] = val.join("=").trim();
+    }
+  }
+};

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,0 +1,14 @@
+import { watch } from "node:fs";
+import { sync } from "./prepare-dev.js";
+import { debounce, root } from "./utils.js";
+
+const ignored = [".build", ".direnv", "node_modules", ".git"];
+
+const debouncedSync = debounce(sync, 5000);
+
+watch(root, { recursive: true }, (_, file) => {
+  if (!file || ignored.some((p) => file.startsWith(p))) return;
+  debouncedSync();
+});
+
+console.log(`Watching ${root}...`);


### PR DESCRIPTION
## Summary

- **Fix `filter_attributes` TypeError**: Added `filter_attributes: []` to `products/products.json` so Eleventy's `ComputedDataProxy` gets a real array during dependency resolution instead of an empty string, fixing the `data.filter_attributes.filter is not a function` error
- **Fix duplicate `index.html` conflict**: Added `"permalink": "/{{ page.fileSlug }}/index.html"` to `pages/pages.json` (matching the chobble-template default) so template pages that don't define their own permalink generate correct URLs instead of all conflicting on `/`
- **Add local build scripts from chobble-client**: Copies the `scripts/` directory enabling `bun run build` and `bun run serve` to work locally without needing the CI pipeline. Key customisations vs chobble-client: excludes `combined/` from source, keeps template `images/` (needed for placeholder SVGs)

## Test plan

- [x] `bun run build` completes successfully from the project root
- [ ] Verify the built site looks correct (pages render, products list works, tags page works)
- [ ] Verify `bun run serve` starts a working dev server

https://claude.ai/code/session_01BmoqaWecfXFNJTP4dQaA9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmoqaWecfXFNJTP4dQaA9U)_